### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This is a TypeScript project that implements a Message Control Protocol (MCP) server for Mailmodo integration with Claude Desktop and other MCP supported client.
 
+<a href="https://glama.ai/mcp/servers/@mailmodo/mailmodo-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mailmodo/mailmodo-mcp/badge" alt="Mailmodo MCP server" />
+</a>
+
 ## Prerequisites
 
 - Node.js (v20 or higher recommended)


### PR DESCRIPTION
This PR adds a badge for the [Mailmodo](https://glama.ai/mcp/servers/@mailmodo/mailmodo-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mailmodo/mailmodo-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mailmodo/mailmodo-mcp/badge" alt="Mailmodo MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.